### PR TITLE
Allow iterator to return `ELF_ITER_NOTFOUND` when not found.

### DIFF
--- a/src/libelfmaster.c
+++ b/src/libelfmaster.c
@@ -1690,7 +1690,7 @@ elf_shared_object_iterator_next(struct elf_shared_object_iterator *iter,
 			entry->basename = iter->current->basename;
 			iter->current = LIST_NEXT(iter->current, _linkage);
 
-			if (entry->path == NULL) {	
+			if (entry->path == NULL) {
 				return ELF_ITER_NOTFOUND;
 			}
 			if (ldso_insert_yield_cache(iter, entry->path) == false) {
@@ -1702,9 +1702,14 @@ elf_shared_object_iterator_next(struct elf_shared_object_iterator *iter,
 	}
 	entry->path = (char *)ldso_cache_bsearch(iter, iter->current->basename);
 	if (entry->path == NULL) {
-		elf_error_set(error, "ldso_cache_bsearch(%p, %s) failed",
+		// dependancy was not found on current system, return expected values
+		// to point to next dependancy while informing caller that it was just NOTFOUND
+		elf_error_set(error, "ldso_cache_bsearch(%p, %s) failed to find",
 		    iter, iter->current->basename);
-		goto err;
+		entry->path = iter->current->path;
+		entry->basename = iter->current->basename;
+		iter->current = LIST_NEXT(iter->current, _linkage);
+		return ELF_ITER_NOTFOUND;
 	}
 
 next_basename:


### PR DESCRIPTION
Previously, when using `elf_shared_object_iterator_next`, if `ldso_cache_bsearch`
fails to find a file, it would return an error, causing the iterator to become useless
and no longer iterate. This will allow the caller to consume an `ELF_ITER_NOTFOUND`
event and continue processing dependancies.