### PR TITLE
arm32/arm64 initial support

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -40,6 +40,7 @@ x86:
 	./stripx test_stripped
 	./stripx test32_stripped
 arm:
+	$(CC_AARCH64) -O0 -ggdb symbols.c ../src/libelfmaster.a -o symbols
 	$(CC_AARCH64) -N -static -nostdlib nostdlib.c -o nostdlib_aarch64
 	$(CC_AARCH64) -Wl,-z,separate-code test.c -o test_scop_pie_aarch64
 	$(CC_AARCH64) -no-pie -Wl,-z,separate-code test.c -o test_scop_binary_aarch64

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -43,6 +43,6 @@ arm:
 	$(CC_AARCH64) -N -static -nostdlib nostdlib.c -o nostdlib_aarch64
 	$(CC_AARCH64) -Wl,-z,separate-code test.c -o test_scop_pie_aarch64
 	$(CC_AARCH64) -no-pie -Wl,-z,separate-code test.c -o test_scop_binary_aarch64
-
+	$(CC_AARCH64) -g -fPIC -pie elfparse.c ../src/libelfmaster.a -o elfparse
 clean:
 	rm elfparse ldd plt_dump plt_dump2 sections eh_frame test test2 test32bit_pie check_static_pie test_pie test_stripped test32bit stripx symbols checksec test32_stripped test_scop_binary elf_text nostdlib nostdlib32 test_scop test32_scop

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,5 +1,7 @@
 CC=gcc
+CC_AARCH64=aarch64-linux-gnu-gcc
 all:
+x86:
 	$(CC) -O0 -g -fPIC -pie elfparse.c ../src/libelfmaster.a -o elfparse
 	$(CC) -O0 -g merged.c ../src/libelfmaster.a -o merged
 	$(CC) -O0 -g ldd.c ../src/libelfmaster.a -o ldd
@@ -11,10 +13,10 @@ all:
 	$(CC) -O2 -g eh_frame.c ../src/libelfmaster.a -o eh_frame
 	$(CC) -O2 -g checksec.c ../src/libelfmaster.a -o checksec
 	$(CC) -O2 -g -fPIC -pie test.c -o test_pie
-	$(CC) -O2 -no-pie test.c ../src/libelfmaster.a -o test
+	$(CC) -O2 -no-pie -Wl,-z,noseparate-code test.c ../src/libelfmaster.a -o test
 	$(CC) -O2 -fPIC -pie test.c ../src/libelfmaster.a -o test2_pie
 	$(CC) -O2 -no-pie test.c ../src/libelfmaster.a -o test_stripped
-	$(CC) -O2 -no-pie -m32 test.c ../src/libelfmaster.a -o test32bit
+	$(CC) -O2 -no-pie -Wl,-z,noseparate-code -m32 test.c ../src/libelfmaster.a -o test32bit
 	$(CC) -O2 -fPIC -pie -m32 test.c ../src/libelfmaster.a -o test32bit_pie
 	$(CC) -no-pie -m32 test.c -o test32_stripped
 	$(CC) -m32 -fPIC -pie -Wl,-z,separate-code test.c -o test32_scop
@@ -36,5 +38,10 @@ all:
 	$(CC) phoff.c -o phoff ../src/libelfmaster.a
 	./stripx test_stripped
 	./stripx test32_stripped
+arm:
+	$(CC_AARCH64) -N -static -nostdlib nostdlib.c -o nostdlib_aarch64
+	$(CC_AARCH64) -Wl,-z,separate-code test.c -o test_scop_pie_aarch64
+	$(CC_AARCH64) -no-pie -Wl,-z,separate-code test.c -o test_scop_binary_aarch64
+
 clean:
 	rm elfparse ldd plt_dump plt_dump2 sections eh_frame test test2 test32bit_pie check_static_pie test_pie test_stripped test32bit stripx symbols checksec test32_stripped test_scop_binary elf_text nostdlib nostdlib32 test_scop test32_scop

--- a/examples/ldd.c
+++ b/examples/ldd.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv)
 
 	//elf_lxc_set_rootfs(&obj, "/cont/arch/rootfs");
 	if (elf_shared_object_iterator_init(&obj, &so_iter,
-	    "/cont/arch/rootfs/etc/ld.so.cache", /*ELF_SO_LDSO_FAST_F|ELF_SO_IGNORE_VDSO_F|*/ELF_SO_RESOLVE_F|ELF_SO_RESOLVE_ALL_F, &error) == false) {
+	    NULL, /*ELF_SO_LDSO_FAST_F|ELF_SO_IGNORE_VDSO_F|*/ELF_SO_RESOLVE_F|ELF_SO_RESOLVE_ALL_F, &error) == false) {
 		fprintf(stderr, "elf_shared_object_iterator_init failed: %s\n",
 		    elf_error_msg(&error));
 		return -1;

--- a/examples/read_mem.c
+++ b/examples/read_mem.c
@@ -29,9 +29,8 @@ int main(int argc, char **argv)
 		fprintf(stderr, "%s\n", elf_error_msg(&error));
 		return -1;
 	}
-
-	elf_symbol_by_name(&obj, "main", &sym);
-	res = elf_read_address(&obj, sym.value, &qw, ELF_QWORD);
+	
+	res = elf_read_address(&obj, 0x10fe8, &qw, ELF_QWORD);
 	if (res == true)
 		printf("read value: %lx\n", qw);
 	return 0;

--- a/examples/symbols.c
+++ b/examples/symbols.c
@@ -35,11 +35,13 @@ int main(int argc, char **argv)
 		fprintf(stderr, "%s\n", elf_error_msg(&error));
 		return -1;
 	}
+#if 0
 	elf_dynsym_iterator_init(&obj, &ds_iter);
 	while (elf_dynsym_iterator_next(&ds_iter, &symbol) == ELF_ITER_OK) {
 		printf("%s: %#lx-%#lx\n",symbol.name, symbol.value,
 		    symbol.value + symbol.size);
 	}
+#endif
 	elf_symtab_iterator_init(&obj, &sm_iter);
 	while (elf_symtab_iterator_next(&sm_iter, &symbol) == ELF_ITER_OK) {
 		printf("%s: %#lx-%#lx\n",symbol.name, symbol.value,

--- a/include/internal.h
+++ b/include/internal.h
@@ -59,6 +59,22 @@ struct cache_file {
 #define CACHEMAGIC_NEW "glibc-ld.so.cache"
 #define CACHE_VERSION "1.1"
 
+/*
+ * Definitions of cache flags taken from glibc's sysdeps/ldconfig.h
+ * XXX re-name-space these definitions? i.e. FLAG_ANY becomes
+ * ELF_LDSO_FLAG_ANY
+ */
+#define FLAG_ANY                        -1
+#define FLAG_TYPE_MASK                  0x00ff
+#define FLAG_LIBC4                      0x0000
+#define FLAG_ELF                        0x0001
+#define FLAG_ELF_LIBC5                  0x0002
+#define FLAG_ELF_LIBC6                  0x0003
+#define FLAG_X8664_LIBX32               0x0800
+#define FLAG_ARM_LIBHF                  0x0900
+#define FLAG_AARCH64_LIB64              0x0a00
+#define FLAG_ARM_LIBSF                  0x0b00
+
 #define ELF_LDSO_CACHE_OLD (1 << 0)
 #define ELF_LDSO_CACHE_NEW (1 << 1)
 

--- a/include/libelfmaster.h
+++ b/include/libelfmaster.h
@@ -863,7 +863,7 @@ bool elf_read_offset(elfobj_t *, uint64_t, uint64_t *, typewidth_t);
 
 bool elf_write_address(elfobj_t *, uint64_t, uint64_t, typewidth_t width);
 
-ssize_t elf_scop_text_filesz(elfobj_t *);
+size_t __attribute__((deprecated)) elf_scop_text_filesz(elfobj_t *);
 uint64_t elf_executable_text_offset(elfobj_t *);
 uint64_t elf_executable_text_base(elfobj_t *);
 

--- a/include/libelfmaster.h
+++ b/include/libelfmaster.h
@@ -37,6 +37,7 @@
 #include <search.h>
 #include <sys/queue.h>
 #include <sys/stat.h>
+#include <assert.h>
 
 #define peu_probable __glibc_unlikely
 

--- a/include/libelfmaster.h
+++ b/include/libelfmaster.h
@@ -567,7 +567,7 @@ typedef struct elf_shared_object_iterator {
 #define ELF_LOAD_F_ULEXEC	(1UL << 4) //Used for ulexec based debugging API
 #define ELF_LOAD_F_MAP_WRITE	(1UL << 5)
 #define ELF_LOAD_F_LXC_MODE	(1UL << 6) // Used when scanning binaries within an LXC container
-
+#define ELF_LOAD_F_PRIV_MAP	(1UL << 7) // Used in conjunction with ELF_LOAD_F_MODIFY but uses private mapping.
 /*
  * Loads an ELF object of any type, for reading or modifying.
  * arg1: file path
@@ -962,6 +962,13 @@ elf_section_count(elfobj_t *obj)
 {
 
 	return obj->section_count;
+}
+
+static inline size_t
+elf_dynamic_size(elfobj_t *obj)
+{
+
+	return obj->dynamic_size;
 }
 
 ssize_t elf_phdr_table_size(elfobj_t *);

--- a/include/libelfmaster.h
+++ b/include/libelfmaster.h
@@ -96,6 +96,8 @@ typedef struct elf_error {
 typedef enum elf_arch {
 	i386,
 	x64,
+	arm,
+	aarch64,
 	unsupported
 } elf_arch_t;
 
@@ -124,7 +126,8 @@ typedef enum elf_obj_flags {
 	ELF_FORENSICS_F =		(1 << 16),  /* elf sections at the least are reconstructed */
 	ELF_DT_DEBUG_F =		(1 << 17),
 	ELF_SCOP_F =			(1 << 18), /* secure code partitioning */
-	ELF_MERGED_SEGMENTS_F =		(1 << 19)  /* Merged text+data segment, i.e. gcc -nostdlib -N -static test.c -o test */
+	ELF_MERGED_SEGMENTS_F =		(1 << 19),  /* Merged text+data segment, i.e. gcc -nostdlib -N -static */
+	ELF_SECURE_PLT_F =		(1 << 20)
 } elf_obj_flags_t;
 
 /*

--- a/src/internal.c
+++ b/src/internal.c
@@ -251,6 +251,13 @@ build_plt_data(struct elfobj *obj)
 		secure_plt = true;
 	}
 	/*
+	 * Rarely, but too often nonetheless the entsize is set to 0
+	 * in some ELF's .plt
+	 */
+	if (plt.entsize == 0) {
+		plt.entsize = 16; // for ARM/ARM64/x86_32/x86_64 16 is the default size
+	}
+	/*
 	 * We can use the relocation iterator at this point, since all of its
 	 * necessary components have been set already within elfobj *
 	 */
@@ -295,6 +302,7 @@ build_plt_data(struct elfobj *obj)
 		plt_node = malloc(sizeof(*plt_node));
 		if (plt_node == NULL)
 			return false;
+		DEBUG_LOG("Adding PLT entry(%s): %#lx\n", r_entry.symname, plt_addr);
 		plt_node->addr = plt_addr;
 		plt_node->symname = r_entry.symname;
 		LIST_INSERT_HEAD(&obj->list.plt, plt_node, _linkage);

--- a/src/internal.c
+++ b/src/internal.c
@@ -215,6 +215,7 @@ build_plt_data(struct elfobj *obj)
 			return false;
 		}
 	} else {
+		obj->flags |= ELF_SECURE_PLT_F;
 		secure_plt = true;
 	}
 	/*
@@ -505,6 +506,17 @@ ldso_cache_check_flags(struct elf_shared_object_iterator *iter,
 	} else if (iter->obj->arch == x64) {
 		if (flags == 0x303)
 			return true;
+	} else if (iter->obj->arch == aarch64) {
+		if (flags == (FLAG_AARCH64_LIB64 | FLAG_ELF_LIBC6))
+			return true;
+	} else if (iter->obj->arch == arm) {
+		if ((flags == (FLAG_ARM_LIBHF | FLAG_ELF_LIBC6)) ||
+		    flags == (FLAG_ELF_LIBC6)) {
+			return true;
+		} else if ((flags == (FLAG_ARM_LIBSF | FLAG_ELF_LIBC6)) ||
+		    flags == (FLAG_ELF_LIBC6)) {
+			return true;
+		}
 	}
 	return false;
 }
@@ -1380,9 +1392,10 @@ i386:
  * the smallest entry address would be 0x41, assuming the program header
  * table was shifted forward, such as in a reverse text infection.
  */
-#define GLIBC_START_CODE_64	"\x55\x48\x89\xe5\x48" /* enough to identify _start */
-#define GLIBC_START_CODE_64_v2	"\x31\xed\x49\x89\xd1" /* enough to identify _start */
-#define GLIBC_START_CODE_32	"\x31\xed\x5e\x89\xe1" /* enough to identify _start */
+#define GLIBC_START_CODE_x86_64	"\x55\x48\x89\xe5\x48" /* enough to identify _start */
+#define GLIBC_START_CODE_x86_64_v2	"\x31\xed\x49\x89\xd1" /* enough to identify _start */
+#define GLIBC_START_CODE_x86_32	"\x31\xed\x5e\x89\xe1" /* enough to identify _start */
+#define GLIBC_START_CODE_aarch64 "\x1f\x20\x03\xd5\x1d\x00\x80\xd2" /* enough to identify _start */
 
 static uint64_t
 original_ep(elfobj_t *obj)
@@ -1395,16 +1408,24 @@ original_ep(elfobj_t *obj)
 		if (i >= (elf_text_offset(obj) + elf_text_filesz(obj) - 6))
 			return 0;
 		if (obj->arch == x64) {
-			if (memcmp(&inst[i], GLIBC_START_CODE_64,
-			    sizeof(GLIBC_START_CODE_64) - 1) == 0)
+			if (memcmp(&inst[i], GLIBC_START_CODE_x86_64,
+			    sizeof(GLIBC_START_CODE_x86_64) - 1) == 0)
 				return elf_text_base(obj) + inst - marker;
-			else if (memcmp(&inst[i], GLIBC_START_CODE_64_v2,
-				    sizeof(GLIBC_START_CODE_64_v2) - 1) == 0)
+			else if (memcmp(&inst[i], GLIBC_START_CODE_x86_64_v2,
+				    sizeof(GLIBC_START_CODE_x86_64_v2) - 1) == 0)
 					return elf_text_base(obj) + inst - marker;
 		} else if (obj->arch == i386) {
-			if (memcmp(&inst[i], GLIBC_START_CODE_32,
-			    sizeof(GLIBC_START_CODE_32) - 1) == 0)
+			if (memcmp(&inst[i], GLIBC_START_CODE_x86_32,
+			    sizeof(GLIBC_START_CODE_x86_32) - 1) == 0)
 				return elf_text_base(obj) + inst - marker;
+		} else if (obj->arch == aarch64) {
+			if (memcmp(&inst[i], GLIBC_START_CODE_aarch64,
+			    sizeof(GLIBC_START_CODE_aarch64) - 1) == 0)
+				return elf_text_base(obj) + inst - marker;
+		} else if (obj->arch == arm) {
+			/*
+			 * TODO
+			 */
 		}
 	}
 	return 0;

--- a/src/internal.c
+++ b/src/internal.c
@@ -292,13 +292,8 @@ build_plt_data(struct elfobj *obj)
 		e.data = (void *)plt_node;
 		hsearch_r(e, ENTER, &ep, &obj->cache.plt);
 	}
-<<<<<<< HEAD
 	plt0_entsize = elf_arch(obj) == aarch64 ? ELF_AARCH64_PLT0_ENTSIZE : plt.entsize;
 	plt_addr = (secure_plt == true) ? plt.address : plt.address + plt0_entsize;
-
-=======
-	plt_addr = (secure_plt == true) ? plt.address : plt.address + PLT_STUB_LEN;
->>>>>>> origin/master
 	for (;;) {
 		res = elf_relocation_iterator_next(&r_iter, &r_entry);
 		if (res == ELF_ITER_ERROR)

--- a/src/internal.c
+++ b/src/internal.c
@@ -387,8 +387,8 @@ build_symtab_data(struct elfobj *obj)
 	 * and can reconstruct the address and size of the local functions
 	 * that correspond to each FDE within .eh_frame.
 	 */
-	if ((obj->load_flags & ELF_LOAD_F_FORENSICS) &&
-	    insane_section_headers(obj) == true) {
+	if (((obj->load_flags & ELF_LOAD_F_FORENSICS) &&
+	    insane_section_headers(obj) == true) || elf_flags(obj, ELF_SYMTAB_F) == false) {
 		struct elf_symbol_node *symbol;
 		struct elf_eh_frame fde;
 		elf_eh_frame_iterator_t  eh_iter;
@@ -422,6 +422,8 @@ build_symtab_data(struct elfobj *obj)
 			}
 			LIST_INSERT_HEAD(list, symbol, _linkage);
 		}
+		obj->symtab_count = obj->fde_count;
+		assert(obj->symtab_count <= SYMTAB_RECONSTRUCT_COUNT);
 		return true;
 	}
 	/*
@@ -2472,6 +2474,7 @@ dw_get_eh_frame_ranges(struct elfobj *obj)
 		fprintf(stderr, "dw_decode_pointer failed\n");
 		return -1;
 	}
+	printf("fde_count: %d\n", fde_count);
 	LIST_INIT(&obj->list.eh_frame_entries);
 	for (i = 0; i < fde_count; i++) {
 		struct elf_eh_frame_node *eh_node;

--- a/src/internal.c
+++ b/src/internal.c
@@ -858,6 +858,7 @@ load_dynamic_segment_data(struct elfobj *obj)
 		 * reconstruction. We must also adjust elf_data_base and elf_text_base
 		 * to account for SCOP binaries.
 		 */
+#if 0
 		if (entry.value >=
 		    elf_text_base(obj) + elf_text_filesz(obj)) {
 			if (entry.value >= elf_data_base(obj) &&
@@ -872,6 +873,7 @@ load_dynamic_segment_data(struct elfobj *obj)
 				return false;
 			}
 		}
+#endif 
 		obj->dynstr = (char *)&obj->mem[entry.value - elf_text_base(obj)];
 		if (obj->dynstr == NULL)
 			return false;
@@ -1439,7 +1441,7 @@ i386:
 #define GLIBC_START_CODE_x86_64	"\x55\x48\x89\xe5\x48" /* enough to identify _start */
 #define GLIBC_START_CODE_x86_64_v2	"\x31\xed\x49\x89\xd1" /* enough to identify _start */
 #define GLIBC_START_CODE_x86_32	"\x31\xed\x5e\x89\xe1" /* enough to identify _start */
-#define GLIBC_START_CODE_aarch64 "\x1f\x20\x03\xd5\x1d\x00\x80\xd2" /* enough to identify _start */
+#define GLIBC_START_CODE_aarch64 "\x1d\x00\x80\xd2\x1e\x00\x80\xd2" /* enough to identify _start */
 
 static uint64_t
 original_ep(elfobj_t *obj)
@@ -2482,7 +2484,6 @@ dw_get_eh_frame_ranges(struct elfobj *obj)
 		fprintf(stderr, "dw_decode_pointer failed\n");
 		return -1;
 	}
-	printf("fde_count: %d\n", fde_count);
 	LIST_INIT(&obj->list.eh_frame_entries);
 	for (i = 0; i < fde_count; i++) {
 		struct elf_eh_frame_node *eh_node;

--- a/src/libelfmaster.c
+++ b/src/libelfmaster.c
@@ -1031,7 +1031,8 @@ elf_segment_by_index(struct elfobj *obj, uint64_t index, struct elf_segment *seg
 }
 
 /*
- * Get a phdr segment by p_type
+ * Get a phdr segment by p_type --
+ * find the first segment of that type and return.
  */
 bool
 elf_segment_by_p_type(struct elfobj *obj, uint64_t type, struct elf_segment *segment)

--- a/src/libelfmaster.c
+++ b/src/libelfmaster.c
@@ -800,6 +800,8 @@ elf_reloc_type_string(struct elfobj *obj, uint32_t r_type)
 				return "R_ARM_XPC22";
 			case R_ARM_TLS_DTPMOD32:
 				return "R_ARM_TLS_DTPMOD32";
+			default:
+				return "R_ARM_UNKNOWN";
 			/*
 			 * Unfinished, god forbid. there are so many
 			 * ARM relocations :(
@@ -808,7 +810,6 @@ elf_reloc_type_string(struct elfobj *obj, uint32_t r_type)
 		case elfclass64:
 			return "R_AARCH64_UNKNOWN";
 		}
-		return "R_AARCH64_UNKNOWN";
 	}
 	switch(obj->e_class) {
 	case elfclass32:

--- a/src/libelfmaster.c
+++ b/src/libelfmaster.c
@@ -3540,4 +3540,5 @@ elf_close_object(elfobj_t *obj)
 		msync(obj->mem, obj->size, MS_SYNC);
 	}
 	munmap(obj->mem, obj->size);
+	close(obj->fd);
 }

--- a/src/make.sh
+++ b/src/make.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-gcc -DDEBUG -fPIC -ggdb -D_GNU_SOURCE -I../include/ -c *.c
+gcc -fPIC -ggdb -D_GNU_SOURCE -I../include/ -c *.c
 ar -rcs libelfmaster.a internal.o libelfmaster.o
 cp libelfmaster.a /opt/elfmaster/lib/
 cp ../include/libelfmaster.h /opt/elfmaster/include

--- a/src/make.sh
+++ b/src/make.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-gcc -fPIC -ggdb -D_GNU_SOURCE -I../include/ -c *.c
+gcc -DDEBUG -fPIC -ggdb -D_GNU_SOURCE -I../include/ -c *.c
 ar -rcs libelfmaster.a internal.o libelfmaster.o
 cp libelfmaster.a /opt/elfmaster/lib/
 cp ../include/libelfmaster.h /opt/elfmaster/include


### PR DESCRIPTION
This is an early push for some ARM support. libelfmaster now supports ARM including with transitive dependency resolution. It does not printing all of the relocation types yet (Although it does handle them internally correctly). Therefore `elf_reloc_type_string` doesn't print out all of the ARM relocations yet. Now considering there's about 250 relocation types between ARM32/ARM64, this is a pain in the ass.