### PR TITLE
added missing fields for elf_section_by_index() out parameter

### DIFF
--- a/src/libelfmaster.c
+++ b/src/libelfmaster.c
@@ -1397,14 +1397,14 @@ elf_symbol_by_value(struct elfobj *obj, uint64_t addr, struct elf_symbol *out)
 
 	elf_dynsym_iterator_init(obj, &dynsym_iter);
 	while (elf_dynsym_iterator_next(&dynsym_iter, &symbol) == ELF_ITER_OK) {
-		if (addr >= symbol.value && addr <= symbol.value + symbol.size) {
+		if (addr >= symbol.value && addr < symbol.value + symbol.size) {
 			memcpy(out, &symbol, sizeof(symbol));
 			return true;
 		}
 	}
 	elf_symtab_iterator_init(obj, &symtab_iter);
 	while (elf_symtab_iterator_next(&symtab_iter, &symbol) == ELF_ITER_OK) {
-		if (addr >= symbol.value && addr <= symbol.value + symbol.size) {
+		if (addr >= symbol.value && addr < symbol.value + symbol.size) {
 			memcpy(out, &symbol, sizeof(symbol));
 			return true;
 		}

--- a/src/libelfmaster.c
+++ b/src/libelfmaster.c
@@ -1397,14 +1397,14 @@ elf_symbol_by_value(struct elfobj *obj, uint64_t addr, struct elf_symbol *out)
 
 	elf_dynsym_iterator_init(obj, &dynsym_iter);
 	while (elf_dynsym_iterator_next(&dynsym_iter, &symbol) == ELF_ITER_OK) {
-		if (addr >= symbol.value && addr < symbol.value + symbol.size) {
+		if (addr >= symbol.value && addr <= symbol.value + symbol.size) {
 			memcpy(out, &symbol, sizeof(symbol));
 			return true;
 		}
 	}
 	elf_symtab_iterator_init(obj, &symtab_iter);
 	while (elf_symtab_iterator_next(&symtab_iter, &symbol) == ELF_ITER_OK) {
-		if (addr >= symbol.value && addr < symbol.value + symbol.size) {
+		if (addr >= symbol.value && addr <= symbol.value + symbol.size) {
 			memcpy(out, &symbol, sizeof(symbol));
 			return true;
 		}

--- a/src/libelfmaster.c
+++ b/src/libelfmaster.c
@@ -1332,6 +1332,7 @@ elf_section_by_index(struct elfobj *obj, uint32_t index,
 		if (index >= obj->ehdr32->e_shnum)
 			return false;
 		out->name = &obj->shstrtab[obj->shdr32[index].sh_name];
+		out->type = obj->shdr32[index].sh_type;
 		out->link = obj->shdr32[index].sh_link;
 		out->info = obj->shdr32[index].sh_info;
 		out->flags = obj->shdr32[index].sh_flags;
@@ -1339,11 +1340,13 @@ elf_section_by_index(struct elfobj *obj, uint32_t index,
 		out->entsize = obj->shdr32[index].sh_entsize;
 		out->offset = obj->shdr32[index].sh_offset;
 		out->address = obj->shdr32[index].sh_addr;
+		out->size = obj->shdr32[index].sh_size;
 		break;
 	case elfclass64:
 		if (index >= obj->ehdr64->e_shnum)
 			return false;
 		out->name = &obj->shstrtab[obj->shdr64[index].sh_name];
+		out->type = obj->shdr64[index].sh_type;
 		out->link = obj->shdr64[index].sh_link;
 		out->info = obj->shdr64[index].sh_info;
 		out->flags = obj->shdr64[index].sh_flags;
@@ -1351,6 +1354,7 @@ elf_section_by_index(struct elfobj *obj, uint32_t index,
 		out->entsize = obj->shdr64[index].sh_entsize;
 		out->offset = obj->shdr64[index].sh_offset;
 		out->address = obj->shdr64[index].sh_addr;
+		out->size = obj->shdr64[index].sh_size;
 		break;
 	default:
 		return false;


### PR DESCRIPTION
Addresses `sh_type` and `sh_size` not being written to the out parameter of `elf_section_by_index()` in `src/libelfmaster.c`.